### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-wafpolicy
+  name: terraform-az-overlays-wafpolicy
   description: Terraform overlay module for Azure Web Application Firewall policies
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-wafpolicy
+    github.com/project-slug: POps-Rox/terraform-az-overlays-wafpolicy
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-wafpolicy
+    - url: https://github.com/POps-Rox/terraform-az-overlays-wafpolicy
       title: GitHub Repository
       icon: github
 spec:

--- a/examples/Commerical/advanced/main.tf
+++ b/examples/Commerical/advanced/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_waf_policy" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-wafpolicy"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-wafpolicy"
   #version = "~> x.x.x"
   source = "../../.."
 

--- a/examples/Commerical/basic/main.tf
+++ b/examples/Commerical/basic/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_waf_policy" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-wafpolicy"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-wafpolicy"
   #version = "~> x.x.x"
   source = "../../.."
 

--- a/examples/Government/advanced/main.tf
+++ b/examples/Government/advanced/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_waf_policy" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-wafpolicy"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-wafpolicy"
   #version = "~> x.x.x"
   source = "../../.."
 

--- a/examples/Government/basic/main.tf
+++ b/examples/Government/basic/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_waf_policy" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-wafpolicy"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-wafpolicy"
   #version = "~> x.x.x"
   source = "../../.."
 

--- a/modules.waf.policy.scaffolding.tf
+++ b/modules.waf.policy.scaffolding.tf
@@ -6,7 +6,7 @@
 #--------------------------------------
 # This module will lookup the Azure Region and return the short name for the region
 module "mod_azregions" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }
@@ -23,7 +23,7 @@ data "azurerm_resource_group" "rgrp" {
 }
 
 module "mod_scaffold_rg" {
-  source = "github.com/POps-Rox/tf-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
 
   count = var.create_waf_resource_group ? 1 : 0
 


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.