### PR TITLE
fix: post-merge cleanup after Phase 1 4.x migration

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,11 @@
+# Provider configurations for standalone validation and CI.
+# When used as a module, providers are passed by the caller via configuration_aliases.
+
+provider "azurerm" {
+  features {}
+}
+
+provider "azurerm" {
+  alias = "hub_network"
+  features {}
+}


### PR DESCRIPTION
Post-Phase-1 cleanup. Restore providers.tf stub for module with configuration_aliases